### PR TITLE
Rank search results by artist match, dedupe pressings, add Discogs marketplace links

### DIFF
--- a/app/u/[shareSlug]/page.tsx
+++ b/app/u/[shareSlug]/page.tsx
@@ -41,6 +41,14 @@ function ItemGrid({ items }: { items: CollectionItemRow[] }) {
           </div>
           <p className="font-bold">{item.album_title}</p>
           <p>{item.artist}</p>
+          <a
+            href={`https://www.discogs.com/sell/release/${item.discogs_id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-gray-400"
+          >
+            Buy on Discogs
+          </a>
         </div>
       ))}
     </div>

--- a/components/CollectionList.tsx
+++ b/components/CollectionList.tsx
@@ -72,6 +72,14 @@ export default function CollectionList({
               <p className="font-bold">{item.albumTitle}</p>
               <p>{item.artist}</p>
               <p className="text-gray-400">{item.year ?? "-"}</p>
+              <a
+                href={`https://www.discogs.com/sell/release/${item.discogsId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs underline text-gray-400"
+              >
+                Buy on Discogs
+              </a>
             </div>
 
             <button

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -47,7 +47,21 @@ export default function Result({
           </div>
           <p className="text-xs mt-1">
             {concatAlbumDescription(album.formats)}
+            {album.pressingCount && album.pressingCount > 1 ? (
+              <span className="text-gray-400">
+                {" "}
+                &middot; {album.pressingCount} pressings
+              </span>
+            ) : null}
           </p>
+          <a
+            href={`https://www.discogs.com/sell/release/${album.id}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs underline text-gray-400"
+          >
+            Buy on Discogs
+          </a>
         </div>
 
         <div className="flex flex-col gap-2 shrink-0">

--- a/schemas/collections.schemas.ts
+++ b/schemas/collections.schemas.ts
@@ -16,6 +16,8 @@ const AlbumSchema = z.object({
   artist: z.string(),
   year: z.string().optional(),
   formats: FormatsSchema,
+  masterId: z.number().optional(),
+  pressingCount: z.number().optional(),
 });
 
 export type Album = z.infer<typeof AlbumSchema>;

--- a/schemas/discogs.schemas.test.ts
+++ b/schemas/discogs.schemas.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "vitest";
+import { DiscogsSearchResponseSchema } from "./discogs.schemas";
+
+test("accepts a null master_id (release with no master group)", () => {
+  const payload = {
+    pagination: { page: 1, pages: 1 },
+    results: [
+      {
+        id: 1,
+        cover_image: "https://example.com/cover.jpg",
+        title: "Muse - Showbiz",
+        year: "1999",
+        master_id: null,
+        formats: [{ name: "Vinyl", qty: "1" }],
+      },
+    ],
+  };
+
+  expect(() => DiscogsSearchResponseSchema.parse(payload)).not.toThrow();
+});
+
+test("accepts a missing master_id field entirely", () => {
+  const payload = {
+    pagination: { page: 1, pages: 1 },
+    results: [
+      {
+        id: 1,
+        cover_image: "https://example.com/cover.jpg",
+        title: "Muse - Showbiz",
+        year: "1999",
+        formats: [{ name: "Vinyl", qty: "1" }],
+      },
+    ],
+  };
+
+  expect(() => DiscogsSearchResponseSchema.parse(payload)).not.toThrow();
+});
+
+test("accepts a numeric master_id", () => {
+  const payload = {
+    pagination: { page: 1, pages: 1 },
+    results: [
+      {
+        id: 1,
+        cover_image: "https://example.com/cover.jpg",
+        title: "Muse - Showbiz",
+        year: "1999",
+        master_id: 12345,
+        formats: [{ name: "Vinyl", qty: "1" }],
+      },
+    ],
+  };
+
+  expect(() => DiscogsSearchResponseSchema.parse(payload)).not.toThrow();
+});

--- a/schemas/discogs.schemas.ts
+++ b/schemas/discogs.schemas.ts
@@ -11,7 +11,7 @@ const DiscogsSearchResponseSchema = z.object({
       cover_image: z.string(),
       title: z.string(),
       year: z.string().optional(),
-      master_id: z.number().optional(),
+      master_id: z.number().nullable().optional(),
       formats: z.array(
         z.object({
           name: z.string(),

--- a/schemas/discogs.schemas.ts
+++ b/schemas/discogs.schemas.ts
@@ -11,6 +11,7 @@ const DiscogsSearchResponseSchema = z.object({
       cover_image: z.string(),
       title: z.string(),
       year: z.string().optional(),
+      master_id: z.number().optional(),
       formats: z.array(
         z.object({
           name: z.string(),

--- a/utils/dedupeByMaster.test.ts
+++ b/utils/dedupeByMaster.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import dedupeByMaster from "./dedupeByMaster";
+import { Album } from "@/schemas/collections.schemas";
+
+function album(overrides: Partial<Album>): Album {
+  return {
+    id: 1,
+    coverImage: "https://example.com/cover.jpg",
+    albumTitle: "Some Album",
+    artist: "Some Artist",
+    formats: [],
+    ...overrides,
+  };
+}
+
+test("collapses multiple pressings sharing a master_id into one entry", () => {
+  const albums = [
+    album({ id: 1, masterId: 100, albumTitle: "Origin of Symmetry" }),
+    album({ id: 2, masterId: 100, albumTitle: "Origin of Symmetry (Reissue)" }),
+    album({ id: 3, masterId: 100, albumTitle: "Origin of Symmetry (Japan Pressing)" }),
+  ];
+
+  const deduped = dedupeByMaster(albums);
+
+  expect(deduped).toHaveLength(1);
+  expect(deduped[0].id).toBe(1);
+  expect(deduped[0].pressingCount).toBe(3);
+});
+
+test("keeps releases with no master_id as their own separate entries", () => {
+  const albums = [album({ id: 1 }), album({ id: 2 })];
+
+  const deduped = dedupeByMaster(albums);
+
+  expect(deduped).toHaveLength(2);
+  expect(deduped.map((a) => a.pressingCount)).toStrictEqual([1, 1]);
+});
+
+test("preserves the order distinct albums first appear in", () => {
+  const albums = [
+    album({ id: 1, masterId: 200 }),
+    album({ id: 2, masterId: 100 }),
+    album({ id: 3, masterId: 200 }),
+  ];
+
+  const deduped = dedupeByMaster(albums);
+
+  expect(deduped.map((a) => a.id)).toStrictEqual([1, 2]);
+});

--- a/utils/dedupeByMaster.ts
+++ b/utils/dedupeByMaster.ts
@@ -1,0 +1,23 @@
+import { Album } from "@/schemas/collections.schemas";
+
+// Collapses multiple pressings of the same album (grouped by Discogs'
+// master_id) down to one representative entry, keeping whichever pressing
+// appears first -- callers should rank results before deduping so the
+// highest-relevance pressing of each album is the one kept. Releases with
+// no master_id (not part of a master group) are left as their own entry.
+export default function dedupeByMaster(albums: Album[]): Album[] {
+  const seen = new Map<string, Album>();
+
+  for (const album of albums) {
+    const key = album.masterId ? `master-${album.masterId}` : `release-${album.id}`;
+    const existing = seen.get(key);
+
+    if (!existing) {
+      seen.set(key, { ...album, pressingCount: 1 });
+    } else {
+      existing.pressingCount = (existing.pressingCount ?? 1) + 1;
+    }
+  }
+
+  return Array.from(seen.values());
+}

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { DiscogsSearchResponseSchema } from "../schemas/discogs.schemas";
 import splitTitle from "./splitTitle";
 import rankSearchResults from "./rankSearchResults";
+import dedupeByMaster from "./dedupeByMaster";
 import { SearchResponseSchema } from "@/schemas/collections.schemas";
 
 const discogs = {
@@ -29,21 +30,24 @@ const discogs = {
     const narrowedData = DiscogsSearchResponseSchema.parse(data);
 
     const searchResponseData = {
-      data: rankSearchResults(
-        narrowedData.results
-          .filter((album) => Boolean(album.title))
-          .map((album) => {
-            const result = {
-              id: album.id,
-              coverImage: album.cover_image,
-              albumTitle: splitTitle(album.title).album,
-              artist: splitTitle(album.title).artist,
-              year: album.year,
-              formats: album.formats,
-            };
-            return result;
-          }),
-        query.search
+      data: dedupeByMaster(
+        rankSearchResults(
+          narrowedData.results
+            .filter((album) => Boolean(album.title))
+            .map((album) => {
+              const result = {
+                id: album.id,
+                coverImage: album.cover_image,
+                albumTitle: splitTitle(album.title).album,
+                artist: splitTitle(album.title).artist,
+                year: album.year,
+                formats: album.formats,
+                masterId: album.master_id,
+              };
+              return result;
+            }),
+          query.search
+        )
       ),
       currentPage: narrowedData.pagination.page,
       isLastPage:

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { DiscogsSearchResponseSchema } from "../schemas/discogs.schemas";
 import splitTitle from "./splitTitle";
+import rankSearchResults from "./rankSearchResults";
 import { SearchResponseSchema } from "@/schemas/collections.schemas";
 
 const discogs = {
@@ -28,19 +29,22 @@ const discogs = {
     const narrowedData = DiscogsSearchResponseSchema.parse(data);
 
     const searchResponseData = {
-      data: narrowedData.results
-        .filter((album) => Boolean(album.title))
-        .map((album) => {
-          const result = {
-            id: album.id,
-            coverImage: album.cover_image,
-            albumTitle: splitTitle(album.title).album,
-            artist: splitTitle(album.title).artist,
-            year: album.year,
-            formats: album.formats,
-          };
-          return result;
-        }),
+      data: rankSearchResults(
+        narrowedData.results
+          .filter((album) => Boolean(album.title))
+          .map((album) => {
+            const result = {
+              id: album.id,
+              coverImage: album.cover_image,
+              albumTitle: splitTitle(album.title).album,
+              artist: splitTitle(album.title).artist,
+              year: album.year,
+              formats: album.formats,
+            };
+            return result;
+          }),
+        query.search
+      ),
       currentPage: narrowedData.pagination.page,
       isLastPage:
         narrowedData.pagination.page === narrowedData.pagination.pages,

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -42,7 +42,7 @@ const discogs = {
                 artist: splitTitle(album.title).artist,
                 year: album.year,
                 formats: album.formats,
-                masterId: album.master_id,
+                masterId: album.master_id ?? undefined,
               };
               return result;
             }),

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -17,7 +17,10 @@ const discogs = {
       token: process.env.DISCOGS_API_KEY!,
       country: "US",
       format: "Vinyl",
-      per_page: "10",
+      // Fetch a wider pool per page so ranking/deduping has enough real
+      // matches to promote -- with only 10 raw results, an artist search
+      // can easily come back with zero genuine matches to re-rank at all.
+      per_page: "50",
       page: String(query.page),
     });
 

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -27,6 +27,12 @@ const discogs = {
     const result = await fetch(url);
     const data = await result.json();
 
+    if (!result.ok) {
+      throw new Error(
+        `Discogs API returned ${result.status}: ${JSON.stringify(data)}`
+      );
+    }
+
     const narrowedData = DiscogsSearchResponseSchema.parse(data);
 
     const searchResponseData = {

--- a/utils/rankSearchResults.test.ts
+++ b/utils/rankSearchResults.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "vitest";
+import rankSearchResults from "./rankSearchResults";
+import { Album } from "@/schemas/collections.schemas";
+
+function album(overrides: Partial<Album>): Album {
+  return {
+    id: 1,
+    coverImage: "https://example.com/cover.jpg",
+    albumTitle: "Some Album",
+    artist: "Some Artist",
+    formats: [],
+    ...overrides,
+  };
+}
+
+test("boosts an exact artist name match above incidental title matches", () => {
+  const albums = [
+    album({ id: 1, artist: "Amy Winehouse", albumTitle: "My Muse" }),
+    album({ id: 2, artist: "Muse", albumTitle: "Origin of Symmetry" }),
+    album({ id: 3, artist: "Some Tribute Band", albumTitle: "A Tribute to Muse" }),
+  ];
+
+  const ranked = rankSearchResults(albums, "Muse");
+
+  expect(ranked.map((a) => a.id)).toStrictEqual([2, 1, 3]);
+});
+
+test("keeps original relative order for results with the same score", () => {
+  const albums = [
+    album({ id: 1, artist: "Muse", albumTitle: "Absolution" }),
+    album({ id: 2, artist: "Muse", albumTitle: "Black Holes and Revelations" }),
+  ];
+
+  const ranked = rankSearchResults(albums, "Muse");
+
+  expect(ranked.map((a) => a.id)).toStrictEqual([1, 2]);
+});
+
+test("is a no-op for an empty query", () => {
+  const albums = [
+    album({ id: 1, artist: "B Artist" }),
+    album({ id: 2, artist: "A Artist" }),
+  ];
+
+  expect(rankSearchResults(albums, "")).toStrictEqual(albums);
+});
+
+test("matches artist names as whole words, not substrings", () => {
+  const albums = [
+    album({ id: 1, artist: "Amuse Bouche", albumTitle: "Some Album" }),
+    album({ id: 2, artist: "Muse", albumTitle: "Showbiz" }),
+  ];
+
+  const ranked = rankSearchResults(albums, "Muse");
+
+  expect(ranked.map((a) => a.id)).toStrictEqual([2, 1]);
+});

--- a/utils/rankSearchResults.ts
+++ b/utils/rankSearchResults.ts
@@ -1,0 +1,28 @@
+import { Album } from "@/schemas/collections.schemas";
+
+function wordBoundaryMatch(haystack: string, needle: string) {
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(haystack);
+}
+
+function relevanceScore(album: Album, query: string): number {
+  const artist = album.artist.trim();
+  const title = album.albumTitle.trim();
+  const normalizedQuery = query.trim();
+
+  if (artist.toLowerCase() === normalizedQuery.toLowerCase()) return 3;
+  if (wordBoundaryMatch(artist, normalizedQuery)) return 2;
+  if (wordBoundaryMatch(title, normalizedQuery)) return 1;
+  return 0;
+}
+
+export default function rankSearchResults(albums: Album[], query: string): Album[] {
+  if (!query.trim()) return albums;
+
+  // Stable sort (Array#sort is stable in Node/V8) -- results tie on score
+  // keep Discogs' original relevance order relative to each other, we're
+  // only pulling artist-name matches ahead of incidental/track-title matches.
+  return [...albums].sort(
+    (a, b) => relevanceScore(b, query) - relevanceScore(a, query)
+  );
+}


### PR DESCRIPTION
## Summary
- Search results are re-ranked so the artist name actually matching the query (exact match, then word-boundary match) rises above releases where the query only hit a stray track title or unrelated credit — fixes the "searching Muse pulls up random unrelated stuff" problem
- Near-identical pressings of the same album (reissues, regional variants, etc.) are now collapsed into one entry (grouped by Discogs' `master_id`), showing "+N pressings" instead of listing every one separately
- Every album — in search results, `/collection`, `/wishlist`, and the public `/u/<share-slug>` page — now links out to that release's Discogs marketplace listing ("Buy on Discogs"), so someone can actually click through and buy an album off a friend's wishlist

## Notes
- Considered switching search itself to Discogs' `master` type (one canonical entry per album from the API directly) instead of client-side deduping, but that risks the `format=Vinyl` filter behaving differently when a master's "main" release isn't vinyl, and this environment can't reach the live Discogs API to verify — deduping release-search results (which are already proven working) gets the same practical result with less risk.
- The marketplace link pattern (`discogs.com/sell/release/<id>`) is based on documented Discogs conventions but hasn't been click-verified live from this environment — worth confirming it resolves correctly on the preview.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds
- [x] `npx vitest run` passes (21 tests, 7 new covering ranking + dedup)
- [ ] Manually verify on preview: search "Muse" and confirm the band's albums lead, confirm pressing counts look right, click a "Buy on Discogs" link and confirm it resolves


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ry4JsM6sgZZ2YdYgzN8WCj)_