### PR TITLE
Fix search API crashing on Discogs failures

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -21,6 +21,14 @@ export async function GET(
     );
   }
 
-  const res = await discogs.search(query);
-  return NextResponse.json(res);
+  try {
+    const res = await discogs.search(query);
+    return NextResponse.json(res);
+  } catch (error) {
+    console.error("Discogs search failed:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch search results" },
+      { status: 502 }
+    );
+  }
 }

--- a/components/SearchResult.tsx
+++ b/components/SearchResult.tsx
@@ -20,6 +20,11 @@ export default function SearchResult({ searchValue }: { searchValue: string }) {
         });
         const res = await fetch("/api/search?" + params);
         const data = await res.json();
+        if (!res.ok) {
+          throw new Error(
+            typeof data?.error === "string" ? data.error : "Search failed"
+          );
+        }
         const parsedData = SearchResponseSchema.parse(data);
         return parsedData;
       },
@@ -30,6 +35,7 @@ export default function SearchResult({ searchValue }: { searchValue: string }) {
         }
         return undefined;
       },
+      retry: false,
     });
 
   const { data: collectionItems } = useCollectionItems("collection");
@@ -43,7 +49,7 @@ export default function SearchResult({ searchValue }: { searchValue: string }) {
   const wishlistIds = new Set(wishlistItems?.map((item) => item.discogsId));
 
   if (error) {
-    return <h3>Error</h3>;
+    return <h3>{error.message || "Something went wrong. Please try again."}</h3>;
   }
 
   return (


### PR DESCRIPTION
Handle Discogs API errors in the search route so it always returns parseable JSON instead of crashing with an empty 500 body, and surface the real error message on the client instead of a misleading "No results found". Also disable query retries since Discogs failures are deterministic and retrying could leave the query stuck paused when the tab loses focus.