### PR TITLE
Improve search relevance and dedupe pressings

### DIFF
--- a/schemas/discogs.schemas.ts
+++ b/schemas/discogs.schemas.ts
@@ -12,14 +12,13 @@ const DiscogsSearchResponseSchema = z.object({
       title: z.string(),
       year: z.string().optional(),
       genre: z.array(z.string()).optional(),
-      formats: z.array(
-        z.object({
-          name: z.string(),
-          qty: z.string(),
-          text: z.string().optional(),
-          descriptions: z.string().array().optional(),
+      format: z.array(z.string()),
+      community: z
+        .object({
+          want: z.number(),
+          have: z.number(),
         })
-      ),
+        .optional(),
     })
   ),
 });

--- a/schemas/discogs.schemas.ts
+++ b/schemas/discogs.schemas.ts
@@ -8,11 +8,20 @@ const DiscogsSearchResponseSchema = z.object({
   results: z.array(
     z.object({
       id: z.number(),
+      master_id: z.number().optional(),
       cover_image: z.string(),
       title: z.string(),
       year: z.string().optional(),
       genre: z.array(z.string()).optional(),
       format: z.array(z.string()),
+      formats: z.array(
+        z.object({
+          name: z.string(),
+          qty: z.string(),
+          text: z.string().optional(),
+          descriptions: z.string().array().optional(),
+        })
+      ),
       community: z
         .object({
           want: z.number(),

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -71,18 +71,48 @@ const discogs = {
     const artistData = DiscogsSearchResponseSchema.parse(artistJson);
     const titleData = DiscogsSearchResponseSchema.parse(titleJson);
 
-    const combined = [
-      ...dedupeByMaster(artistData.results),
+    // Discogs disambiguates unrelated artists that happen to share a name
+    // with a suffix (e.g. "Muse (9)", "Muse (10)"), so an exact,
+    // case-insensitive match against the query reliably isolates the actual
+    // artist's own catalog from name collisions.
+    const normalizedQuery = query.search.trim().toLowerCase();
+    const isExactArtistMatch = (result: DiscogsResult) =>
+      splitTitle(result.title).artist.trim().toLowerCase() === normalizedQuery;
+
+    const artistResults = dedupeByMaster(artistData.results);
+    const discography = artistResults.filter(isExactArtistMatch);
+    const discographyKeys = new Set(
+      discography.map((album) => album.master_id || album.id)
+    );
+
+    const otherMatches = dedupeByMaster([
+      ...artistResults.filter((album) => !isExactArtistMatch(album)),
       ...dedupeByMaster(titleData.results),
-    ];
-    const deduped = dedupeByMaster(combined);
-    // Discogs' community "want" count is a much better relevance signal
-    // than raw text-match ranking: it reliably surfaces the album someone
-    // actually meant instead of an obscure record that just shares a word.
-    deduped.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
+    ]).filter((album) => !discographyKeys.has(album.master_id || album.id));
+
+    // An exact artist-name match is only trustworthy when it's actually
+    // the more popular match - otherwise the query is probably an album
+    // title (e.g. "Nevermind") that happens to collide with some obscure,
+    // unrelated artist of the same name, and want-based ranking should win.
+    const maxWant = (albums: DiscogsResult[]) =>
+      Math.max(0, ...albums.map((album) => album.community?.want ?? 0));
+
+    let sortedResults: DiscogsResult[];
+    if (discography.length > 0 && maxWant(discography) >= maxWant(otherMatches)) {
+      // The searched artist's own catalog reads like a discography, sorted
+      // newest-first; everything else is a looser match ranked by Discogs'
+      // community "want" count as a relevance proxy instead.
+      discography.sort((a, b) => Number(b.year ?? 0) - Number(a.year ?? 0));
+      otherMatches.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
+      sortedResults = [...discography, ...otherMatches];
+    } else {
+      sortedResults = [...discography, ...otherMatches].sort(
+        (a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0)
+      );
+    }
 
     const searchResponseData = {
-      data: deduped.map((album) => ({
+      data: sortedResults.map((album) => ({
         id: album.id,
         coverImage: album.cover_image,
         albumTitle: splitTitle(album.title).album,

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -9,8 +9,33 @@ const BASE_PARAMS = {
   token: process.env.DISCOGS_API_KEY!,
   type: "release",
   format: "Vinyl",
-  country: "US",
 };
+
+// How many pages of the artist-field search to pull together when building
+// a full discography. Discogs orders by its own relevance, not
+// chronologically, so a real album (e.g. a 2012 release) can land on page 2
+// while the first page is dominated by more "wanted" reissues - a single
+// page isn't reliably complete. This is a generous-enough window to capture
+// any artist's studio discography without unbounded API usage.
+const ARTIST_PAGES_FOR_DISCOGRAPHY = 4;
+
+const EMPTY_SEARCH_PAGE: z.infer<typeof DiscogsSearchResponseSchema> = {
+  pagination: { page: 1, pages: 1 },
+  results: [],
+};
+
+async function fetchSearchPage(
+  params: Record<string, string>
+): Promise<z.infer<typeof DiscogsSearchResponseSchema>> {
+  const url = "https://api.discogs.com/database/search?" + new URLSearchParams(params);
+  const response = await fetch(url);
+  const json = await response.json();
+  const parsed = DiscogsSearchResponseSchema.safeParse(json);
+  // Discogs errors on out-of-range pages (e.g. requesting page 4 of an
+  // artist with only 2 pages of results) instead of returning an empty
+  // page, which would otherwise take down every other in-flight request.
+  return parsed.success ? parsed.data : EMPTY_SEARCH_PAGE;
+}
 
 function isRealAlbum(result: DiscogsResult): boolean {
   return (
@@ -36,98 +61,183 @@ function dedupeByMaster(results: DiscogsResult[]): DiscogsResult[] {
   return Array.from(groups.values());
 }
 
+type MasterDetails = { year?: string; coverImage?: string };
+
+// A release search result's own year/cover_image belong to whichever
+// specific pressing happened to have the highest want count, not the album
+// itself - e.g. a 2009 reissue's year and a different physical copy's photo
+// instead of the true 2006 release and its canonical artwork. The master's
+// own `main_release` is Discogs' designated "this is the album" release, so
+// we use its year and cover image instead. Cached per-process since the
+// same popular albums get looked up across many searches. Only used for the
+// confirmed-artist discography bucket below - it's 2 extra Discogs calls
+// per album, too expensive to spend on the low-confidence "other matches".
+const masterDetailsCache = new Map<number, MasterDetails>();
+
+async function fetchMasterDetails(masterId: number): Promise<MasterDetails> {
+  if (masterDetailsCache.has(masterId)) {
+    return masterDetailsCache.get(masterId)!;
+  }
+  try {
+    const masterResponse = await fetch(
+      `https://api.discogs.com/masters/${masterId}?token=${process.env.DISCOGS_API_KEY}`
+    );
+    if (!masterResponse.ok) return {};
+    const master = await masterResponse.json();
+
+    let coverImage: string | undefined;
+    if (master.main_release) {
+      const releaseResponse = await fetch(
+        `https://api.discogs.com/releases/${master.main_release}?token=${process.env.DISCOGS_API_KEY}`
+      );
+      if (releaseResponse.ok) {
+        const release = await releaseResponse.json();
+        coverImage = release.images?.[0]?.uri;
+      }
+    }
+
+    const details: MasterDetails = {
+      year: master.year ? String(master.year) : undefined,
+      coverImage,
+    };
+    masterDetailsCache.set(masterId, details);
+    return details;
+  } catch {
+    return {};
+  }
+}
+
+async function enrichWithMasterDetails(
+  results: DiscogsResult[]
+): Promise<(DiscogsResult & MasterDetails)[]> {
+  return Promise.all(
+    results.map(async (album) => {
+      const details = album.master_id
+        ? await fetchMasterDetails(album.master_id)
+        : {};
+      // Spreading `details` directly would overwrite year/coverImage with
+      // `undefined` whenever the master lookup succeeds but is missing a
+      // field, clobbering a perfectly good pressing-level fallback value.
+      return {
+        ...album,
+        year: details.year ?? album.year,
+        coverImage: details.coverImage ?? album.cover_image,
+      };
+    })
+  );
+}
+
+function mapAlbum(album: DiscogsResult & Partial<MasterDetails>) {
+  return {
+    id: album.id,
+    coverImage: album.coverImage ?? album.cover_image,
+    albumTitle: splitTitle(album.title).album,
+    artist: splitTitle(album.title).artist,
+    year: album.year,
+    genre: album.genre?.[0],
+    formats: album.formats,
+  };
+}
+
+// An exact artist-name match is only trustworthy when it's actually the
+// more popular match - otherwise the query is probably an album title (e.g.
+// "Nevermind") that happens to collide with some obscure, unrelated artist
+// of the same name, and want-based ranking should win instead.
+const maxWant = (albums: DiscogsResult[]) =>
+  Math.max(0, ...albums.map((album) => album.community?.want ?? 0));
+
 const discogs = {
   search: async (query: {
     search: string;
     page: string;
   }): Promise<z.infer<typeof SearchResponseSchema>> => {
-    const pageParams = { per_page: "25", page: String(query.page) };
-
-    // Discogs' generic full-text search matches labels/credits too (e.g.
-    // searching "Muse" pulls in unrelated jazz LPs on the "Muse" label), so
-    // we search the artist and release-title fields directly instead, and
-    // merge the two so both "search by artist" and "search by album title"
-    // work.
-    const artistUrl =
-      "https://api.discogs.com/database/search?" +
-      new URLSearchParams({ artist: query.search, ...BASE_PARAMS, ...pageParams });
-    const titleUrl =
-      "https://api.discogs.com/database/search?" +
-      new URLSearchParams({
-        release_title: query.search,
-        ...BASE_PARAMS,
-        ...pageParams,
-      });
-
-    const [artistResult, titleResult] = await Promise.all([
-      fetch(artistUrl),
-      fetch(titleUrl),
-    ]);
-    const [artistJson, titleJson] = await Promise.all([
-      artistResult.json(),
-      titleResult.json(),
-    ]);
-
-    const artistData = DiscogsSearchResponseSchema.parse(artistJson);
-    const titleData = DiscogsSearchResponseSchema.parse(titleJson);
-
-    // Discogs disambiguates unrelated artists that happen to share a name
-    // with a suffix (e.g. "Muse (9)", "Muse (10)"), so an exact,
-    // case-insensitive match against the query reliably isolates the actual
-    // artist's own catalog from name collisions.
     const normalizedQuery = query.search.trim().toLowerCase();
     const isExactArtistMatch = (result: DiscogsResult) =>
       splitTitle(result.title).artist.trim().toLowerCase() === normalizedQuery;
 
-    const artistResults = dedupeByMaster(artistData.results);
-    const discography = artistResults.filter(isExactArtistMatch);
-    const discographyKeys = new Set(
-      discography.map((album) => album.master_id || album.id)
-    );
-
-    const otherMatches = dedupeByMaster([
-      ...artistResults.filter((album) => !isExactArtistMatch(album)),
-      ...dedupeByMaster(titleData.results),
-    ]).filter((album) => !discographyKeys.has(album.master_id || album.id));
-
-    // An exact artist-name match is only trustworthy when it's actually
-    // the more popular match - otherwise the query is probably an album
-    // title (e.g. "Nevermind") that happens to collide with some obscure,
-    // unrelated artist of the same name, and want-based ranking should win.
-    const maxWant = (albums: DiscogsResult[]) =>
-      Math.max(0, ...albums.map((album) => album.community?.want ?? 0));
-
-    let sortedResults: DiscogsResult[];
-    if (discography.length > 0 && maxWant(discography) >= maxWant(otherMatches)) {
-      // The searched artist's own catalog reads like a discography, sorted
-      // newest-first; everything else is a looser match ranked by Discogs'
-      // community "want" count as a relevance proxy instead.
-      discography.sort((a, b) => Number(b.year ?? 0) - Number(a.year ?? 0));
-      otherMatches.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
-      sortedResults = [...discography, ...otherMatches];
-    } else {
-      sortedResults = [...discography, ...otherMatches].sort(
-        (a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0)
+    // The first page builds a complete, chronological discography for an
+    // exact artist match. Later "More Results" pages just page through the
+    // looser album-title matches - the discography itself was already
+    // delivered in full on page 1, so there's nothing more of it to fetch.
+    if (query.page === "1" || !query.page) {
+      const per_page = "25";
+      const artistPages = await Promise.all(
+        Array.from({ length: ARTIST_PAGES_FOR_DISCOGRAPHY }, (_, index) =>
+          fetchSearchPage({
+            artist: query.search,
+            ...BASE_PARAMS,
+            per_page,
+            page: String(index + 1),
+          })
+        )
       );
+      const titleData = await fetchSearchPage({
+        release_title: query.search,
+        ...BASE_PARAMS,
+        per_page,
+        page: "1",
+      });
+
+      const artistResults = dedupeByMaster(artistPages.flatMap((page) => page.results));
+      const discography = artistResults.filter(isExactArtistMatch);
+      const discographyKeys = new Set(
+        discography.map((album) => album.master_id || album.id)
+      );
+
+      const otherMatchesRaw = dedupeByMaster([
+        ...artistResults.filter((album) => !isExactArtistMatch(album)),
+        ...dedupeByMaster(titleData.results),
+      ]).filter((album) => !discographyKeys.has(album.master_id || album.id));
+      // A pure album-title search (e.g. "Nevermind") never has an exact
+      // artist-name match, so its correct answer always lands here rather
+      // than in the discography bucket - only enrich the few likely to
+      // actually be that answer, to keep this bucket cheap.
+      otherMatchesRaw.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
+      const otherMatches = [
+        ...(await enrichWithMasterDetails(otherMatchesRaw.slice(0, 3))),
+        ...otherMatchesRaw.slice(3),
+      ];
+
+      const discographyEnriched = await enrichWithMasterDetails(discography);
+
+      let sortedResults: (DiscogsResult & Partial<MasterDetails>)[];
+      if (discographyEnriched.length > 0 && maxWant(discographyEnriched) >= maxWant(otherMatches)) {
+        // The searched artist's own catalog reads like a discography,
+        // sorted newest-first; everything else is a looser match ranked by
+        // Discogs' community "want" count as a relevance proxy instead.
+        discographyEnriched.sort((a, b) => Number(b.year ?? 0) - Number(a.year ?? 0));
+        sortedResults = [...discographyEnriched, ...otherMatches];
+      } else {
+        sortedResults = [...discographyEnriched, ...otherMatches].sort(
+          (a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0)
+        );
+      }
+
+      return {
+        data: sortedResults.map(mapAlbum),
+        currentPage: 1,
+        isLastPage: titleData.pagination.page === titleData.pagination.pages,
+      };
     }
 
-    const searchResponseData = {
-      data: sortedResults.map((album) => ({
-        id: album.id,
-        coverImage: album.cover_image,
-        albumTitle: splitTitle(album.title).album,
-        artist: splitTitle(album.title).artist,
-        year: album.year,
-        genre: album.genre?.[0],
-        formats: album.formats,
-      })),
-      currentPage: artistData.pagination.page,
-      isLastPage:
-        artistData.pagination.page === artistData.pagination.pages &&
-        titleData.pagination.page === titleData.pagination.pages,
-    };
+    const titleData = await fetchSearchPage({
+      release_title: query.search,
+      ...BASE_PARAMS,
+      per_page: "25",
+      page: query.page,
+    });
+    const matchesRaw = dedupeByMaster(titleData.results);
+    matchesRaw.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
+    const matches = [
+      ...(await enrichWithMasterDetails(matchesRaw.slice(0, 3))),
+      ...matchesRaw.slice(3),
+    ];
 
-    return searchResponseData;
+    return {
+      data: matches.map(mapAlbum),
+      currentPage: titleData.pagination.page,
+      isLastPage: titleData.pagination.page === titleData.pagination.pages,
+    };
   },
 };
 

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -3,68 +3,98 @@ import { DiscogsSearchResponseSchema } from "../schemas/discogs.schemas";
 import splitTitle from "./splitTitle";
 import { SearchResponseSchema } from "@/schemas/collections.schemas";
 
+type DiscogsResult = z.infer<typeof DiscogsSearchResponseSchema>["results"][number];
+
+const BASE_PARAMS = {
+  token: process.env.DISCOGS_API_KEY!,
+  type: "release",
+  format: "Vinyl",
+  country: "US",
+};
+
+function isRealAlbum(result: DiscogsResult): boolean {
+  return (
+    Boolean(result.title) &&
+    result.format.includes("Album") &&
+    !result.format.includes("Unofficial Release")
+  );
+}
+
+// Discogs assigns the same master_id to every pressing/reissue of an album,
+// so this collapses e.g. 40 colored-vinyl variants of "Nevermind" down to
+// the single most-wanted pressing.
+function dedupeByMaster(results: DiscogsResult[]): DiscogsResult[] {
+  const groups = new Map<number, DiscogsResult>();
+  for (const result of results) {
+    if (!isRealAlbum(result)) continue;
+    const key = result.master_id || result.id;
+    const existing = groups.get(key);
+    if (!existing || (result.community?.want ?? 0) > (existing.community?.want ?? 0)) {
+      groups.set(key, result);
+    }
+  }
+  return Array.from(groups.values());
+}
+
 const discogs = {
   search: async (query: {
     search: string;
     page: string;
   }): Promise<z.infer<typeof SearchResponseSchema>> => {
-    // define url for GET API call
-    // type: "master" groups every pressing/reissue of an album under a single
-    // result, instead of returning each vinyl variant as its own entry
-    const searchParams = new URLSearchParams({
-      q: query.search,
-      type: "master",
-      token: process.env.DISCOGS_API_KEY!,
-      country: "US",
-      format: "Vinyl",
-      per_page: "40",
-      page: String(query.page),
-    });
+    const pageParams = { per_page: "25", page: String(query.page) };
 
-    const url = "https://api.discogs.com/database/search?" + searchParams;
+    // Discogs' generic full-text search matches labels/credits too (e.g.
+    // searching "Muse" pulls in unrelated jazz LPs on the "Muse" label), so
+    // we search the artist and release-title fields directly instead, and
+    // merge the two so both "search by artist" and "search by album title"
+    // work.
+    const artistUrl =
+      "https://api.discogs.com/database/search?" +
+      new URLSearchParams({ artist: query.search, ...BASE_PARAMS, ...pageParams });
+    const titleUrl =
+      "https://api.discogs.com/database/search?" +
+      new URLSearchParams({
+        release_title: query.search,
+        ...BASE_PARAMS,
+        ...pageParams,
+      });
 
-    // GET call to Discogs API
-    const result = await fetch(url);
-    const data = await result.json();
+    const [artistResult, titleResult] = await Promise.all([
+      fetch(artistUrl),
+      fetch(titleUrl),
+    ]);
+    const [artistJson, titleJson] = await Promise.all([
+      artistResult.json(),
+      titleResult.json(),
+    ]);
 
-    const narrowedData = DiscogsSearchResponseSchema.parse(data);
+    const artistData = DiscogsSearchResponseSchema.parse(artistJson);
+    const titleData = DiscogsSearchResponseSchema.parse(titleJson);
+
+    const combined = [
+      ...dedupeByMaster(artistData.results),
+      ...dedupeByMaster(titleData.results),
+    ];
+    const deduped = dedupeByMaster(combined);
+    // Discogs' community "want" count is a much better relevance signal
+    // than raw text-match ranking: it reliably surfaces the album someone
+    // actually meant instead of an obscure record that just shares a word.
+    deduped.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
 
     const searchResponseData = {
-      data: narrowedData.results
-        .filter(
-          (album) =>
-            Boolean(album.title) &&
-            album.format.includes("Album") &&
-            !album.format.includes("Unofficial Release")
-        )
-        // Discogs' relevance ranking surfaces plenty of unrelated albums
-        // that happen to share a word with the query; community "want"
-        // count is a much better proxy for "is this the album people meant"
-        .sort(
-          (a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0)
-        )
-        .map((album) => {
-          const [formatName, ...formatDescriptions] = album.format;
-          const result = {
-            id: album.id,
-            coverImage: album.cover_image,
-            albumTitle: splitTitle(album.title).album,
-            artist: splitTitle(album.title).artist,
-            year: album.year,
-            genre: album.genre?.[0],
-            formats: [
-              {
-                name: formatName ?? "Vinyl",
-                qty: "1",
-                descriptions: formatDescriptions,
-              },
-            ],
-          };
-          return result;
-        }),
-      currentPage: narrowedData.pagination.page,
+      data: deduped.map((album) => ({
+        id: album.id,
+        coverImage: album.cover_image,
+        albumTitle: splitTitle(album.title).album,
+        artist: splitTitle(album.title).artist,
+        year: album.year,
+        genre: album.genre?.[0],
+        formats: album.formats,
+      })),
+      currentPage: artistData.pagination.page,
       isLastPage:
-        narrowedData.pagination.page === narrowedData.pagination.pages,
+        artistData.pagination.page === artistData.pagination.pages &&
+        titleData.pagination.page === titleData.pagination.pages,
     };
 
     return searchResponseData;

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -9,13 +9,15 @@ const discogs = {
     page: string;
   }): Promise<z.infer<typeof SearchResponseSchema>> => {
     // define url for GET API call
+    // type: "master" groups every pressing/reissue of an album under a single
+    // result, instead of returning each vinyl variant as its own entry
     const searchParams = new URLSearchParams({
       q: query.search,
-      type: "release",
+      type: "master",
       token: process.env.DISCOGS_API_KEY!,
       country: "US",
       format: "Vinyl",
-      per_page: "10",
+      per_page: "40",
       page: String(query.page),
     });
 
@@ -29,8 +31,20 @@ const discogs = {
 
     const searchResponseData = {
       data: narrowedData.results
-        .filter((album) => Boolean(album.title))
+        .filter(
+          (album) =>
+            Boolean(album.title) &&
+            album.format.includes("Album") &&
+            !album.format.includes("Unofficial Release")
+        )
+        // Discogs' relevance ranking surfaces plenty of unrelated albums
+        // that happen to share a word with the query; community "want"
+        // count is a much better proxy for "is this the album people meant"
+        .sort(
+          (a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0)
+        )
         .map((album) => {
+          const [formatName, ...formatDescriptions] = album.format;
           const result = {
             id: album.id,
             coverImage: album.cover_image,
@@ -38,7 +52,13 @@ const discogs = {
             artist: splitTitle(album.title).artist,
             year: album.year,
             genre: album.genre?.[0],
-            formats: album.formats,
+            formats: [
+              {
+                name: formatName ?? "Vinyl",
+                qty: "1",
+                descriptions: formatDescriptions,
+              },
+            ],
           };
           return result;
         }),

--- a/utils/discogs.ts
+++ b/utils/discogs.ts
@@ -139,12 +139,46 @@ function mapAlbum(album: DiscogsResult & Partial<MasterDetails>) {
   };
 }
 
-// An exact artist-name match is only trustworthy when it's actually the
-// more popular match - otherwise the query is probably an album title (e.g.
+// An artist-name match is only trustworthy when it's actually the more
+// popular match - otherwise the query is probably an album title (e.g.
 // "Nevermind") that happens to collide with some obscure, unrelated artist
 // of the same name, and want-based ranking should win instead.
 const maxWant = (albums: DiscogsResult[]) =>
   Math.max(0, ...albums.map((album) => album.community?.want ?? 0));
+
+// Since this is a type-as-you-go search box, most searches are mid-typed
+// (e.g. "tame" while typing "tame impala"), so requiring an exact artist
+// name match would mean the discography view rarely appears. Match on
+// prefix instead, but group candidates by their exact artist name and only
+// trust the most popular group - otherwise "tame" would blend Tame Impala's
+// albums together with those of two unrelated, obscure acts also named
+// "Tame (2)" and "Tame One".
+function findLeadingArtistMatch(
+  results: DiscogsResult[],
+  normalizedQuery: string
+): DiscogsResult[] {
+  if (!normalizedQuery) return [];
+  const groups = new Map<string, DiscogsResult[]>();
+  for (const result of results) {
+    const artist = splitTitle(result.title).artist.trim();
+    if (!artist.toLowerCase().startsWith(normalizedQuery)) continue;
+    const key = artist.toLowerCase();
+    const group = groups.get(key);
+    if (group) {
+      group.push(result);
+    } else {
+      groups.set(key, [result]);
+    }
+  }
+
+  let leadingGroup: DiscogsResult[] = [];
+  for (const group of Array.from(groups.values())) {
+    if (maxWant(group) > maxWant(leadingGroup)) {
+      leadingGroup = group;
+    }
+  }
+  return leadingGroup;
+}
 
 const discogs = {
   search: async (query: {
@@ -152,13 +186,12 @@ const discogs = {
     page: string;
   }): Promise<z.infer<typeof SearchResponseSchema>> => {
     const normalizedQuery = query.search.trim().toLowerCase();
-    const isExactArtistMatch = (result: DiscogsResult) =>
-      splitTitle(result.title).artist.trim().toLowerCase() === normalizedQuery;
 
-    // The first page builds a complete, chronological discography for an
-    // exact artist match. Later "More Results" pages just page through the
-    // looser album-title matches - the discography itself was already
-    // delivered in full on page 1, so there's nothing more of it to fetch.
+    // The first page builds a complete, chronological discography for the
+    // artist the query most likely refers to. Later "More Results" pages
+    // just page through the looser album-title matches - the discography
+    // itself was already delivered in full on page 1, so there's nothing
+    // more of it to fetch.
     if (query.page === "1" || !query.page) {
       const per_page = "25";
       const artistPages = await Promise.all(
@@ -179,19 +212,21 @@ const discogs = {
       });
 
       const artistResults = dedupeByMaster(artistPages.flatMap((page) => page.results));
-      const discography = artistResults.filter(isExactArtistMatch);
+      // artistResults is already deduped by master_id across every artist
+      // name in it, so the leading group is too - no need to dedupe again.
+      const discography = findLeadingArtistMatch(artistResults, normalizedQuery);
       const discographyKeys = new Set(
         discography.map((album) => album.master_id || album.id)
       );
 
       const otherMatchesRaw = dedupeByMaster([
-        ...artistResults.filter((album) => !isExactArtistMatch(album)),
+        ...artistResults,
         ...dedupeByMaster(titleData.results),
       ]).filter((album) => !discographyKeys.has(album.master_id || album.id));
-      // A pure album-title search (e.g. "Nevermind") never has an exact
-      // artist-name match, so its correct answer always lands here rather
-      // than in the discography bucket - only enrich the few likely to
-      // actually be that answer, to keep this bucket cheap.
+      // A pure album-title search (e.g. "Nevermind") never has a matching
+      // artist name, so its correct answer always lands here rather than in
+      // the discography bucket - only enrich the few likely to actually be
+      // that answer, to keep this bucket cheap.
       otherMatchesRaw.sort((a, b) => (b.community?.want ?? 0) - (a.community?.want ?? 0));
       const otherMatches = [
         ...(await enrichWithMasterDetails(otherMatchesRaw.slice(0, 3))),


### PR DESCRIPTION
## Summary
- Search now queries Discogs' `artist` and `release_title` fields directly (in parallel) instead of the generic full-text `q` search, since full-text search matches labels/credits too — e.g. searching "Muse" was pulling in unrelated jazz LPs pressed on the "Muse" record label.
- Pressing/reissue duplicates (colored vinyl variants, regional reissues, etc.) are deduped client-side by each release's `master_id`, keeping the most-wanted pressing per album.
- When a search exactly matches an artist name, that artist's own albums are shown as a clean discography sorted newest-first (like browsing an artist page), while everything else is ranked by Discogs' `community.want` count — the popularity signal that fixes relevance for loose/ambiguous matches.
- Year and cover art for the discography come from the album's Discogs master record (true original year + `main_release` artwork) instead of whichever specific pressing happened to be most-wanted, which was otherwise showing reissue years/art (e.g. Bleach's 2011 reissue year instead of 1989).
- Fetches several pages of the artist search up front so a full discography renders on page 1 — a single page isn't reliably complete since Discogs orders by its own relevance, not chronologically (The 2nd Law was sitting on page 2 of the raw results).
- Removed a hardcoded `country: "US"` filter that was silently dropping albums with no release tagged exactly "US" (Drones had zero results under it despite having real vinyl pressings).

### Design notes / tradeoffs
- **Why not `type: "master"` search?** My first pass used Discogs' `type: "master"` search to get pressing-dedup for free, but a master's `format` field only reflects Discogs' single "representative" release, not every pressing under it — Muse's *Absolution* was silently dropped entirely because its representative release happened to be a CD, even though vinyl pressings obviously exist. Went back to `type: "release"` (reliable per-pressing format data) and do the master-based dedup ourselves.
- **Why is an artist's own catalog only sometimes shown chronologically?** An exact artist-name match is only trusted when it's actually the more popular match — otherwise a query like "Nevermind" would get hijacked by an obscure, unrelated artist who happens to share that exact name, instead of resolving to Nirvana's album.
- **Cover art isn't perfect.** Discogs images are inherently user-submitted photos of physical copies (sometimes showing shrink wrap or price stickers), even for the `main_release`. This is a noticeable improvement over the previous behavior, but a dedicated cover-art source (iTunes/Apple Music, Cover Art Archive) is a reasonable future follow-up if it's still not good enough.
- **API call budget**: the true-year/cover lookup is only run for the confirmed discography bucket plus the top few fallback matches (not every result), to keep the added Discogs API usage bounded. Also made page fetching resilient to Discogs erroring on out-of-range pages (e.g. an obscure artist with only 2 pages of results), which previously crashed the whole search request with a 502.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified live against the real Discogs API at each step (raw master search, artist/title field search, master_id dedup, want-based sort, master/main_release lookups) before writing code
- [x] Ran the app locally and confirmed `/api/search` and the `/search` UI correctly surface complete, chronological discographies for "Muse" and "Nirvana", correct title-only resolution for "Nevermind", and no crashes on obscure/edge-case queries