### PR TITLE
Warm Analog redesign + wishlist, photo uploads, and search/UX polish

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import clsx from "clsx";
 import { createClient } from "@/lib/supabase/client";
@@ -40,6 +40,8 @@ function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.Re
 const inputClass =
   "w-full rounded-[10px] border border-field-border bg-field px-4 py-[13px] font-body text-[15px] text-text outline-none";
 
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+
 export default function Register() {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -49,12 +51,41 @@ export default function Register() {
   const [username, setUsername] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [avatarVariant, setAvatarVariant] = useState(0);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
   const [genres, setGenres] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!avatarFile) {
+      setAvatarPreview(null);
+      return;
+    }
+    const url = URL.createObjectURL(avatarFile);
+    setAvatarPreview(url);
+    return () => URL.revokeObjectURL(url);
+  }, [avatarFile]);
 
   const toggleGenre = (genre: string) => {
     setGenres((prev) =>
       prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre]
     );
+  };
+
+  const handleAvatarFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      setAvatarError("Please choose an image file.");
+      return;
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      setAvatarError("Images must be smaller than 5MB.");
+      return;
+    }
+    setAvatarError(null);
+    setAvatarFile(file);
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -93,6 +124,33 @@ export default function Register() {
       if (signUpError) {
         setError(signUpError.message);
         return;
+      }
+
+      // A binary file can't ride along in signUp's metadata like the other
+      // fields do, so it has to be uploaded after the account exists. That
+      // requires an authenticated session, which we only have immediately
+      // when email confirmation is off -- if confirmation is required, the
+      // photo is skipped here and the user keeps their picked avatar variant.
+      if (data.session && data.user && avatarFile) {
+        try {
+          const ext = avatarFile.name.split(".").pop() || "jpg";
+          const path = `${data.user.id}/avatar.${ext}`;
+          const { error: uploadError } = await supabase.storage
+            .from("avatars")
+            .upload(path, avatarFile, { upsert: true, contentType: avatarFile.type });
+
+          if (!uploadError) {
+            const {
+              data: { publicUrl },
+            } = supabase.storage.from("avatars").getPublicUrl(path);
+            await supabase
+              .from("profiles")
+              .update({ avatar_url: publicUrl })
+              .eq("id", data.user.id);
+          }
+        } catch {
+          // Non-fatal -- registration still succeeds without the photo.
+        }
       }
 
       if (data.session) {
@@ -173,35 +231,72 @@ export default function Register() {
         {/* Avatar */}
         <SectionLabel>Profile picture</SectionLabel>
         <p className="mb-[18px] text-[14px] text-muted">
-          Pick a friendly avatar. Photo uploads are coming soon.
+          Upload a photo, or pick a friendly avatar instead.
         </p>
-        <div className="mb-[34px] flex flex-wrap gap-[14px]">
-          <button
-            type="button"
-            disabled
-            title="Photo uploads are coming soon"
-            className="flex h-16 w-16 cursor-not-allowed flex-col items-center justify-center gap-[3px] rounded-2xl border-2 border-border bg-surface opacity-60"
+        <div className="mb-[16px] flex flex-wrap gap-[14px]">
+          <label
+            className={clsx(
+              "flex h-16 w-16 cursor-pointer flex-col items-center justify-center gap-[3px] overflow-hidden rounded-2xl border-2 bg-surface",
+              avatarPreview ? "border-accent" : "border-border"
+            )}
           >
-            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-accent to-[#d98a4a]">
-              <Icon type="no-img" size="small" className="text-white" />
-            </div>
-            <span className="font-display text-[11px] font-semibold text-muted">Upload</span>
-          </button>
+            <input
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={handleAvatarFileChange}
+            />
+            {avatarPreview ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={avatarPreview}
+                alt="Avatar preview"
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <>
+                <div className="flex h-11 w-11 items-center justify-center rounded-full bg-gradient-to-br from-accent to-[#d98a4a]">
+                  <Icon type="no-img" size="small" className="text-white" />
+                </div>
+                <span className="font-display text-[11px] font-semibold text-muted">
+                  Upload
+                </span>
+              </>
+            )}
+          </label>
+          {avatarPreview ? (
+            <button
+              type="button"
+              onClick={() => setAvatarFile(null)}
+              className="flex h-16 w-16 flex-col items-center justify-center gap-1 rounded-2xl border-2 border-dashed border-pill-border text-muted"
+            >
+              <Icon type="clear" size="small" />
+              <span className="font-display text-[11px] font-semibold">Remove</span>
+            </button>
+          ) : null}
           {Array.from({ length: AVATAR_VARIANT_COUNT }, (_, i) => i).map((variant) => (
             <button
               type="button"
               key={variant}
-              onClick={() => setAvatarVariant(variant)}
+              onClick={() => {
+                setAvatarVariant(variant);
+                setAvatarFile(null);
+              }}
               aria-label={`Avatar style ${variant + 1}`}
               className={clsx(
                 "flex h-16 w-16 items-center justify-center rounded-2xl border-2 bg-surface",
-                avatarVariant === variant ? "border-accent" : "border-border"
+                !avatarPreview && avatarVariant === variant ? "border-accent" : "border-border"
               )}
             >
               <Avatar variant={variant} size={52} />
             </button>
           ))}
         </div>
+        {avatarError ? (
+          <p className="mb-[18px] text-[13px] text-accent">{avatarError}</p>
+        ) : (
+          <div className="mb-[18px]" />
+        )}
 
         {/* Taste */}
         <SectionLabel>Your taste</SectionLabel>

--- a/components/Icon.tsx
+++ b/components/Icon.tsx
@@ -15,7 +15,8 @@ type Props = {
     | "moon"
     | "home"
     | "user"
-    | "disc";
+    | "disc"
+    | "trash";
   className?: string;
   size?: "xsmall" | "small" | "medium";
 };
@@ -242,6 +243,24 @@ export default function Icon({ type, className, size = "medium" }: Props) {
       >
         <circle cx="12" cy="12" r="9" />
         <circle cx="12" cy="12" r="2.5" />
+      </svg>
+    );
+  }
+
+  if (type === "trash") {
+    return (
+      <svg
+        className={clsx(sizes[size], className)}
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.6}
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4.5 6.75h15m-13 0 .866 12.142A2 2 0 0 0 9.36 20.75h5.28a2 2 0 0 0 1.994-1.858L17.5 6.75m-9 0V4.5a1.5 1.5 0 0 1 1.5-1.5h2a1.5 1.5 0 0 1 1.5 1.5v2.25m-4 4v6m4-6v6"
+        />
       </svg>
     );
   }

--- a/components/Library.tsx
+++ b/components/Library.tsx
@@ -261,7 +261,6 @@ export default function Library() {
                 <GridCard
                   key={item.id}
                   item={item}
-                  listType={libTab}
                   onRemove={() => remove.mutate(item.discogsId)}
                 />
               ))}
@@ -285,11 +284,9 @@ export default function Library() {
 
 function GridCard({
   item,
-  listType,
   onRemove,
 }: {
   item: CollectionItem;
-  listType: ListType;
   onRemove: () => void;
 }) {
   return (
@@ -303,13 +300,9 @@ function GridCard({
         <button
           onClick={onRemove}
           title="Remove"
-          className="absolute right-[10px] top-[10px] flex h-[29px] w-[29px] items-center justify-center rounded-full bg-status-bg backdrop-blur-[6px]"
+          className="absolute right-[10px] top-[10px] flex h-[29px] w-[29px] items-center justify-center rounded-full bg-status-bg text-muted backdrop-blur-[6px]"
         >
-          {listType === "collection" ? (
-            <Icon type="check" size="xsmall" className="text-accent" />
-          ) : (
-            <Icon type="heart-filled" size="xsmall" className="text-accent" />
-          )}
+          <Icon type="trash" size="xsmall" />
         </button>
       </div>
       <p className="mb-[3px] font-display text-[15px] font-semibold leading-[1.25] tracking-[-0.01em] text-text">

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -68,7 +68,30 @@ function ThemeToggle({ iconOnly = false }: { iconOnly?: boolean }) {
   );
 }
 
-function NavAvatar({ size, avatarVariant }: { size: number; avatarVariant?: number | null }) {
+function NavAvatar({
+  size,
+  avatarVariant,
+  avatarUrl,
+}: {
+  size: number;
+  avatarVariant?: number | null;
+  avatarUrl?: string | null;
+}) {
+  if (avatarUrl) {
+    // Uploaded photos live in the user's own Supabase project (an
+    // arbitrary, per-deployment hostname), so next/image's remotePatterns
+    // allowlist doesn't apply here -- a plain <img> is simplest.
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={avatarUrl}
+        alt="Your avatar"
+        className="shrink-0 rounded-full object-cover"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
   if (avatarVariant !== null && avatarVariant !== undefined) {
     return <Avatar variant={avatarVariant} size={size} animate={false} />;
   }
@@ -209,7 +232,11 @@ export default function NavBar() {
             ))}
             <ThemeToggle />
             <Link href="/user-profile">
-              <NavAvatar size={34} avatarVariant={profile?.avatarVariant} />
+              <NavAvatar
+                size={34}
+                avatarVariant={profile?.avatarVariant}
+                avatarUrl={profile?.avatarUrl}
+              />
             </Link>
           </div>
         </div>
@@ -222,7 +249,11 @@ export default function NavBar() {
           <div className="flex items-center gap-3">
             <ThemeToggle iconOnly />
             <Link href="/user-profile">
-              <NavAvatar size={34} avatarVariant={profile?.avatarVariant} />
+              <NavAvatar
+                size={34}
+                avatarVariant={profile?.avatarVariant}
+                avatarUrl={profile?.avatarUrl}
+              />
             </Link>
           </div>
         </div>

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -82,12 +82,16 @@ export default function Result({
           />
         </div>
       ) : (
-        <Link
-          href="/login"
-          className="whitespace-nowrap text-[13px] font-medium text-muted underline"
-        >
-          Sign in to save
-        </Link>
+        <p className="whitespace-nowrap text-[13px] font-medium text-muted">
+          <Link href="/register" className="text-accent underline">
+            Register
+          </Link>{" "}
+          or{" "}
+          <Link href="/login" className="underline">
+            log in
+          </Link>{" "}
+          to save
+        </p>
       )}
     </div>
   );

--- a/components/SearchResult.tsx
+++ b/components/SearchResult.tsx
@@ -1,5 +1,8 @@
+import { useState } from "react";
+import Link from "next/link";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import Result from "./Result";
+import Icon from "./Icon";
 import { Album, SearchResponseSchema } from "@/schemas/collections.schemas";
 import ResultLoading from "./ResultLoading";
 import useUser from "@/lib/supabase/useUser";
@@ -8,8 +11,29 @@ import {
   useToggleCollectionItem,
 } from "@/lib/hooks/useCollectionItems";
 
+function RegisterBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div className="mb-4 flex items-center justify-between gap-3 rounded-[12px] border border-pill-border bg-surface px-4 py-3">
+      <p className="text-[13px] font-medium text-text">
+        <Link href="/register" className="font-semibold text-accent underline">
+          Create a free account
+        </Link>{" "}
+        to save records you find here to your collection or wishlist.
+      </p>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 text-muted"
+      >
+        <Icon type="clear" size="xsmall" />
+      </button>
+    </div>
+  );
+}
+
 export default function SearchResult({ searchValue }: { searchValue: string }) {
   const { user } = useUser();
+  const [bannerDismissed, setBannerDismissed] = useState(false);
   const query = searchValue.trim();
 
   const { data, error, isFetching, fetchNextPage, hasNextPage } =
@@ -85,6 +109,9 @@ export default function SearchResult({ searchValue }: { searchValue: string }) {
 
   return (
     <div className="flex flex-col">
+      {!user && hasResults && !bannerDismissed ? (
+        <RegisterBanner onDismiss={() => setBannerDismissed(true)} />
+      ) : null}
       {data?.pages.map((page) =>
         page.data.map((album: Album) => (
           <Result

--- a/components/app/Explore.tsx
+++ b/components/app/Explore.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { useDebounce } from "react-use";
 import Icon from "@/components/Icon";
 import Cover from "@/components/Cover";
+import SearchBar from "@/components/SearchBar";
+import SearchResult from "@/components/SearchResult";
 import useProfile from "@/lib/supabase/useProfile";
 import {
   useCollectionItems,
@@ -36,12 +39,16 @@ function topGenresOf(items: CollectionItem[], max: number) {
 function AlbumMiniCard({
   album,
   inCollection,
-  onToggle,
+  onToggleCollection,
+  inWishlist,
+  onToggleWishlist,
   isNew,
 }: {
   album: Album;
   inCollection: boolean;
-  onToggle: () => void;
+  onToggleCollection: () => void;
+  inWishlist: boolean;
+  onToggleWishlist: () => void;
   isNew?: boolean;
 }) {
   return (
@@ -57,13 +64,22 @@ function AlbumMiniCard({
             New
           </span>
         ) : null}
-        <button
-          onClick={onToggle}
-          title={inCollection ? "In Collection" : "Add to collection"}
-          className="absolute right-[10px] top-[10px] flex h-[29px] w-[29px] items-center justify-center rounded-full bg-status-bg text-accent backdrop-blur-[6px]"
-        >
-          <Icon type={inCollection ? "check" : "plus"} size="xsmall" />
-        </button>
+        <div className="absolute right-[10px] top-[10px] flex flex-col gap-[7px]">
+          <button
+            onClick={onToggleCollection}
+            title={inCollection ? "In Collection" : "Add to collection"}
+            className="flex h-[29px] w-[29px] items-center justify-center rounded-full bg-status-bg text-accent backdrop-blur-[6px]"
+          >
+            <Icon type={inCollection ? "check" : "plus"} size="xsmall" />
+          </button>
+          <button
+            onClick={onToggleWishlist}
+            title={inWishlist ? "In Wishlist" : "Add to wishlist"}
+            className="flex h-[29px] w-[29px] items-center justify-center rounded-full bg-status-bg text-accent backdrop-blur-[6px]"
+          >
+            <Icon type={inWishlist ? "heart-filled" : "heart"} size="xsmall" />
+          </button>
+        </div>
       </div>
       <p className="mb-px font-display text-[13px] font-semibold leading-[1.2] text-text">
         {album.albumTitle}
@@ -76,14 +92,35 @@ function AlbumMiniCard({
 export default function Explore() {
   const { profile } = useProfile();
   const { data: collection } = useCollectionItems("collection");
+  const { data: wishlist } = useCollectionItems("wishlist");
   const { add: addToCollection, remove: removeFromCollection } =
     useToggleCollectionItem("collection");
+  const { add: addToWishlist, remove: removeFromWishlist } =
+    useToggleCollectionItem("wishlist");
 
   const owned = useMemo(() => collection ?? [], [collection]);
   const ownedIds = useMemo(() => new Set(owned.map((a) => a.discogsId)), [owned]);
+  const wishlistIds = useMemo(
+    () => new Set((wishlist ?? []).map((a) => a.discogsId)),
+    [wishlist]
+  );
 
   const ownedTopGenres = useMemo(() => topGenresOf(owned, 2), [owned]);
-  const genresForQuery = ownedTopGenres.length ? ownedTopGenres : profile?.genres?.slice(0, 2) ?? [];
+
+  // "Recommended for you" should only change on a fresh page load, not every
+  // time an item is added/removed -- otherwise the section visibly reshuffles
+  // right after someone clicks the collection/wishlist icon. Snapshot the
+  // genre signal once the collection query first settles and keep using that
+  // snapshot for the rest of the page's lifetime; the icons themselves stay
+  // reactive since they read `ownedIds`/`wishlistIds` directly.
+  const frozenOwnedGenresRef = useRef<string[] | null>(null);
+  if (frozenOwnedGenresRef.current === null && collection !== undefined) {
+    frozenOwnedGenresRef.current = ownedTopGenres;
+  }
+  const frozenOwnedGenres = frozenOwnedGenresRef.current ?? [];
+  const genresForQuery = frozenOwnedGenres.length
+    ? frozenOwnedGenres
+    : profile?.genres?.slice(0, 2) ?? [];
 
   const { data } = useDiscover(genresForQuery);
 
@@ -91,8 +128,8 @@ export default function Explore() {
   const trending = data?.trending ?? [];
   const newItems = data?.newItems ?? [];
 
-  const recommendedSub = ownedTopGenres.length
-    ? `Based on the ${ownedTopGenres.join(" & ")} in your collection.`
+  const recommendedSub = frozenOwnedGenres.length
+    ? `Based on the ${frozenOwnedGenres.join(" & ")} in your collection.`
     : (profile?.genres?.length ?? 0) > 0
       ? "Based on the genres you picked when you joined."
       : null;
@@ -123,13 +160,26 @@ export default function Explore() {
 
   const recentItems = owned.slice(0, 6);
 
-  const toggleAlbum = (album: Album) => {
+  const toggleCollection = (album: Album) => {
     if (ownedIds.has(album.id)) {
       removeFromCollection.mutate(album.id);
     } else {
       addToCollection.mutate(album);
     }
   };
+
+  const toggleWishlist = (album: Album) => {
+    if (wishlistIds.has(album.id)) {
+      removeFromWishlist.mutate(album.id);
+    } else {
+      addToWishlist.mutate(album);
+    }
+  };
+
+  const [clientSearch, setClientSearch] = useState("");
+  const [serverSearch, setServerSearch] = useState("");
+  useDebounce(() => setServerSearch(clientSearch), 700, [clientSearch]);
+  const isSearching = serverSearch.trim() !== "";
 
   return (
     <main className="mx-auto max-w-[1160px] px-[18px] pb-24 pt-6 dt:px-8 dt:pb-20 dt:pt-10">
@@ -143,132 +193,148 @@ export default function Explore() {
         Fresh picks, this week&apos;s trending records, and gems for your shelf.
       </p>
 
-      <Link
-        href="/search"
-        className="mb-11 flex items-center gap-3 rounded-full border border-field-border bg-field px-[22px] py-[15px] text-[16px] text-muted"
-      >
-        <Icon type="search" size="small" />
-        Search millions of records…
-      </Link>
+      <SearchBar
+        searchValue={clientSearch}
+        onSearch={(value) => {
+          setClientSearch(value);
+          if (value === "") setServerSearch("");
+        }}
+        onClear={() => {
+          setClientSearch("");
+          setServerSearch("");
+        }}
+      />
 
-      {recommended.length > 0 ? (
-        <div className="mb-12">
-          <h2 className="mb-1 font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-            Recommended for you
-          </h2>
-          {recommendedSub ? (
-            <p className="mb-[18px] text-[13px] text-muted">{recommendedSub}</p>
+      {isSearching ? (
+        <SearchResult searchValue={serverSearch} />
+      ) : (
+        <>
+          {recommended.length > 0 ? (
+            <div className="mb-12">
+              <h2 className="mb-1 font-display text-[21px] font-bold tracking-[-0.02em] text-text">
+                Recommended for you
+              </h2>
+              {recommendedSub ? (
+                <p className="mb-[18px] text-[13px] text-muted">{recommendedSub}</p>
+              ) : null}
+              <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
+                {recommended.map((album) => (
+                  <AlbumMiniCard
+                    key={album.id}
+                    album={album}
+                    inCollection={ownedIds.has(album.id)}
+                    onToggleCollection={() => toggleCollection(album)}
+                    inWishlist={wishlistIds.has(album.id)}
+                    onToggleWishlist={() => toggleWishlist(album)}
+                  />
+                ))}
+              </div>
+            </div>
           ) : null}
-          <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
-            {recommended.map((album) => (
-              <AlbumMiniCard
-                key={album.id}
-                album={album}
-                inCollection={ownedIds.has(album.id)}
-                onToggle={() => toggleAlbum(album)}
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
 
-      {trending.length > 0 ? (
-        <div className="mb-12">
+          {trending.length > 0 ? (
+            <div className="mb-12">
+              <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
+                Trending now
+              </h2>
+              <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
+                {trending.map((album) => (
+                  <AlbumMiniCard
+                    key={album.id}
+                    album={album}
+                    inCollection={ownedIds.has(album.id)}
+                    onToggleCollection={() => toggleCollection(album)}
+                    inWishlist={wishlistIds.has(album.id)}
+                    onToggleWishlist={() => toggleWishlist(album)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {newItems.length > 0 ? (
+            <div className="mb-12">
+              <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
+                New this week
+              </h2>
+              <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
+                {newItems.map((album) => (
+                  <AlbumMiniCard
+                    key={album.id}
+                    album={album}
+                    inCollection={ownedIds.has(album.id)}
+                    onToggleCollection={() => toggleCollection(album)}
+                    inWishlist={wishlistIds.has(album.id)}
+                    onToggleWishlist={() => toggleWishlist(album)}
+                    isNew
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
           <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-            Trending now
+            Browse by genre
           </h2>
-          <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
-            {trending.map((album) => (
-              <AlbumMiniCard
-                key={album.id}
-                album={album}
-                inCollection={ownedIds.has(album.id)}
-                onToggle={() => toggleAlbum(album)}
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      {newItems.length > 0 ? (
-        <div className="mb-12">
-          <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-            New this week
-          </h2>
-          <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
-            {newItems.map((album) => (
-              <AlbumMiniCard
-                key={album.id}
-                album={album}
-                inCollection={ownedIds.has(album.id)}
-                onToggle={() => toggleAlbum(album)}
-                isNew
-              />
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-        Browse by genre
-      </h2>
-      <div className="mb-6 flex flex-wrap gap-[10px]">
-        {browseGenres.map((g) => (
-          <Link
-            key={g.name}
-            href={`/search?q=${encodeURIComponent(g.name)}`}
-            className="flex items-center gap-2 rounded-xl border border-border bg-surface px-[18px] py-[11px] font-display text-[14px] font-semibold text-text"
-          >
-            {g.name}
-            {g.count !== null ? (
-              <span className="font-body text-[13px] font-medium text-muted">{g.count}</span>
-            ) : null}
-          </Link>
-        ))}
-      </div>
-
-      <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-        Browse by decade
-      </h2>
-      <div className="mb-12 flex flex-wrap gap-[10px]">
-        {browseDecades.map((decade) => (
-          <Link
-            key={decade}
-            href={`/search?q=${encodeURIComponent(decade.slice(0, 3))}`}
-            className="rounded-xl border border-border bg-surface px-[18px] py-[11px] font-display text-[14px] font-semibold text-text"
-          >
-            {decade}
-          </Link>
-        ))}
-      </div>
-
-      {recentItems.length > 0 ? (
-        <div>
-          <div className="mb-[18px] flex items-baseline justify-between">
-            <h2 className="font-display text-[21px] font-bold tracking-[-0.02em] text-text">
-              Recently added to your shelf
-            </h2>
-            <Link href="/library" className="font-display text-[14px] font-semibold text-accent">
-              View library →
-            </Link>
-          </div>
-          <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
-            {recentItems.map((item) => (
-              <Link key={item.id} href="/library">
-                <Cover
-                  src={item.coverImage}
-                  alt={`${item.albumTitle} cover image`}
-                  className="relative mb-[10px] aspect-square overflow-hidden rounded-[7px] shadow-cover"
-                />
-                <p className="mb-px font-display text-[13px] font-semibold leading-[1.2] text-text">
-                  {item.albumTitle}
-                </p>
-                <p className="text-[12px] text-muted">{item.artist}</p>
+          <div className="mb-6 flex flex-wrap gap-[10px]">
+            {browseGenres.map((g) => (
+              <Link
+                key={g.name}
+                href={`/search?q=${encodeURIComponent(g.name)}`}
+                className="flex items-center gap-2 rounded-xl border border-border bg-surface px-[18px] py-[11px] font-display text-[14px] font-semibold text-text"
+              >
+                {g.name}
+                {g.count !== null ? (
+                  <span className="font-body text-[13px] font-medium text-muted">{g.count}</span>
+                ) : null}
               </Link>
             ))}
           </div>
-        </div>
-      ) : null}
+
+          <h2 className="mb-[18px] font-display text-[21px] font-bold tracking-[-0.02em] text-text">
+            Browse by decade
+          </h2>
+          <div className="mb-12 flex flex-wrap gap-[10px]">
+            {browseDecades.map((decade) => (
+              <Link
+                key={decade}
+                href={`/search?q=${encodeURIComponent(decade.slice(0, 3))}`}
+                className="rounded-xl border border-border bg-surface px-[18px] py-[11px] font-display text-[14px] font-semibold text-text"
+              >
+                {decade}
+              </Link>
+            ))}
+          </div>
+
+          {recentItems.length > 0 ? (
+            <div>
+              <div className="mb-[18px] flex items-baseline justify-between">
+                <h2 className="font-display text-[21px] font-bold tracking-[-0.02em] text-text">
+                  Recently added to your shelf
+                </h2>
+                <Link href="/library" className="font-display text-[14px] font-semibold text-accent">
+                  View library →
+                </Link>
+              </div>
+              <div className="grid grid-cols-2 gap-[14px_18px] dt:grid-cols-[repeat(auto-fill,minmax(150px,1fr))] dt:gap-5">
+                {recentItems.map((item) => (
+                  <Link key={item.id} href="/library">
+                    <Cover
+                      src={item.coverImage}
+                      alt={`${item.albumTitle} cover image`}
+                      className="relative mb-[10px] aspect-square overflow-hidden rounded-[7px] shadow-cover"
+                    />
+                    <p className="mb-px font-display text-[13px] font-semibold leading-[1.2] text-text">
+                      {item.albumTitle}
+                    </p>
+                    <p className="text-[12px] text-muted">{item.artist}</p>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
     </main>
   );
 }

--- a/components/landing/Landing.tsx
+++ b/components/landing/Landing.tsx
@@ -24,6 +24,25 @@ const STEPS = [
   },
 ];
 
+// The seamless marquee loop (`translateX(-50%)`, see the `marquee` keyframes
+// in styles/globals.css) only looks gapless if a single un-doubled set of
+// covers is already wider than the viewport. The "popular" pool the API
+// returns can come back short (deduped iconic-album lookups often resolve
+// to fewer than 24 unique records), so cycle the available items up to a
+// generous minimum count before doubling -- regardless of how few (or many)
+// items the API handed back, the row always has enough width to loop
+// without a visible gap.
+const MIN_MARQUEE_ITEMS = 24;
+
+function fillMarqueeRow(items: Album[], minCount: number) {
+  if (items.length === 0) return items;
+  const filled: Album[] = [];
+  while (filled.length < minCount) {
+    filled.push(...items);
+  }
+  return filled;
+}
+
 function MarqueeRow({
   items,
   reverse,
@@ -31,7 +50,8 @@ function MarqueeRow({
   items: Album[];
   reverse?: boolean;
 }) {
-  const doubled = [...items, ...items];
+  const filled = fillMarqueeRow(items, MIN_MARQUEE_ITEMS);
+  const doubled = [...filled, ...filled];
   return (
     <div
       className="mb-4 flex w-max gap-4 last:mb-0"
@@ -58,7 +78,7 @@ export default function Landing() {
   const popularPool = data?.popular ?? [];
   const marqueeRow1 = popularPool.slice(0, 12);
   const marqueeRow2Raw = popularPool.slice(12, 24);
-  const marqueeRow2 = marqueeRow2Raw.length >= 4 ? marqueeRow2Raw : [...marqueeRow1].reverse();
+  const marqueeRow2 = marqueeRow2Raw.length > 0 ? marqueeRow2Raw : [...marqueeRow1].reverse();
   const charts = data?.charts ?? [];
 
   return (

--- a/lib/supabase/useProfile.ts
+++ b/lib/supabase/useProfile.ts
@@ -9,6 +9,7 @@ export type Profile = {
   shareSlug: string;
   displayName: string | null;
   avatarVariant: number | null;
+  avatarUrl: string | null;
   genres: string[] | null;
 };
 
@@ -28,7 +29,7 @@ export default function useProfile() {
     const supabase = createClient();
     supabase
       .from("profiles")
-      .select("username, share_slug, display_name, avatar_variant, genres")
+      .select("username, share_slug, display_name, avatar_variant, avatar_url, genres")
       .eq("id", user.id)
       .single()
       .then(({ data }) => {
@@ -39,6 +40,7 @@ export default function useProfile() {
                 shareSlug: data.share_slug,
                 displayName: data.display_name,
                 avatarVariant: data.avatar_variant,
+                avatarUrl: data.avatar_url,
                 genres: data.genres,
               }
             : null

--- a/supabase/migrations/0004_avatar_url.sql
+++ b/supabase/migrations/0004_avatar_url.sql
@@ -1,0 +1,61 @@
+-- Adds support for uploaded profile photos. Registration can now optionally
+-- upload an image to Supabase Storage instead of only picking one of the
+-- illustrated avatar variants (components/Avatar.tsx). Run this once in the
+-- Supabase SQL editor (Project > SQL Editor > New query), same as
+-- 0001_init.sql. The storage bucket + policies below can also be created via
+-- the Storage UI instead -- these statements are just the SQL equivalent.
+
+alter table public.profiles add column if not exists avatar_url text;
+
+-- Registration writes the uploaded photo's public URL here directly (see
+-- app/register/page.tsx) once the account exists, since a binary file can't
+-- ride along in auth signUp metadata the way username/genres/etc. do. This
+-- column just lets it seed from metadata too, for consistency with the rest.
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = public, extensions
+as $$
+begin
+  insert into public.profiles (id, username, share_slug, display_name, avatar_variant, avatar_url, genres)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'username', split_part(new.email, '@', 1), 'collector'),
+    encode(gen_random_bytes(6), 'hex'),
+    new.raw_user_meta_data ->> 'display_name',
+    (new.raw_user_meta_data ->> 'avatar_variant')::int,
+    new.raw_user_meta_data ->> 'avatar_url',
+    case
+      when new.raw_user_meta_data -> 'genres' is null then null
+      else array(select jsonb_array_elements_text(new.raw_user_meta_data -> 'genres'))
+    end
+  );
+  return new;
+end;
+$$;
+
+-- Public "avatars" bucket: readable by anyone (avatars show up in the nav and
+-- on shared profiles), writable only by an authenticated user into their own
+-- `${auth.uid()}/...` folder.
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+create policy "Avatar images are publicly accessible"
+on storage.objects for select
+using (bucket_id = 'avatars');
+
+create policy "Users can upload their own avatar"
+on storage.objects for insert
+to authenticated
+with check (bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text);
+
+create policy "Users can update their own avatar"
+on storage.objects for update
+to authenticated
+using (bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text);
+
+create policy "Users can delete their own avatar"
+on storage.objects for delete
+to authenticated
+using (bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
## Summary
This bundles the previously-unmerged Warm Analog redesign (landing, register, explore, library — from the `warm-analog-redesign` branch, which no longer exists as a remote branch) together with a new batch of feature/UX updates on top of it:

- Add a wishlist button alongside the collection toggle on home page album cards, and stop "Recommended for you" from reshuffling on every add/remove (it now only refreshes on a fresh page load, while the icons themselves still update instantly).
- Fix the signed-out landing marquee so both rows always fill the full viewport width and loop seamlessly instead of visibly gapping.
- Support uploading a profile photo during registration (Supabase Storage), falling back to the illustrated avatar variants. Includes `supabase/migrations/0004_avatar_url.sql`.
- Let signed-out visitors search with register/log-in prompts (dismissible banner + per-result links) instead of a dead end.
- Make the home page search bar search inline instead of navigating to `/search`.
- Swap the library's remove-item icon for a clear trash icon.

## Setup required
Run `supabase/migrations/0004_avatar_url.sql` in the Supabase SQL editor (or create the equivalent `avatars` storage bucket/policies via the UI) before photo uploads will persist.

## Test plan
- [x] `npm run lint` and `npx tsc --noEmit` clean
- [x] `npx vitest run` — 28 tests passing
- [x] Verified live in browser preview: landing marquee fills full width on both rows with no gap; signed-out search shows register banner + per-result prompts; register page file picker/preview/remove works
- [ ] Verify signed-in flows (wishlist icon, frozen recommendations, avatar upload persistence, library trash icon) against a real Supabase project — this dev environment had none configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)