### PR TITLE
Rebrand app name from "Collections" to "Record Collections"

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,7 +17,7 @@ const body = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  title: "Collections App",
+  title: "Record Collections App",
   description: "Collect your favorite records and albums",
 };
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -170,7 +170,7 @@ export default function Register() {
   return (
     <main className="mx-auto max-w-[560px] px-[18px] py-[clamp(32px,5vw,52px)] pb-24 dt:px-6">
       <p className="mb-[14px] font-body text-[12px] uppercase tracking-[0.16em] text-accent">
-        Welcome to Collections
+        Welcome to Record Collections
       </p>
       <h1 className="mb-2 font-display text-[clamp(30px,5vw,40px)] font-extrabold leading-[1.05] tracking-[-0.03em] text-text">
         Create your account

--- a/app/u/[shareSlug]/page.tsx
+++ b/app/u/[shareSlug]/page.tsx
@@ -92,7 +92,7 @@ export default async function SharedCollectionPage({
           <h1 className="mb-1 font-display text-[clamp(26px,6vw,34px)] font-extrabold leading-[1.05] tracking-[-0.03em] text-text">
             {name}&apos;s Collection
           </h1>
-          <p className="text-[15px] text-muted">A public collection on Collections</p>
+          <p className="text-[15px] text-muted">A public collection on Record Collections</p>
         </div>
       </div>
 

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -36,7 +36,7 @@ function Wordmark({ small = false }: { small?: boolean }) {
           small ? "h-2 w-2" : "h-[9px] w-[9px]"
         )}
       />
-      Collections
+      Record Collections
     </Link>
   );
 }

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -18,7 +18,7 @@ export default function SiteFooter() {
       <div className="mx-auto flex max-w-[1160px] flex-wrap items-center justify-between gap-x-7 gap-y-4 px-[18px] py-5 dt:px-8">
         <div className="flex flex-wrap items-center gap-5">
           <span className="font-display text-[14px] font-bold tracking-[-0.01em] text-[#9aa3b8]">
-            Collections
+            Record Collections
           </span>
           <div className="flex flex-wrap gap-[18px]">
             {links.map((label) => (


### PR DESCRIPTION
## Summary
Updated all user-facing text references throughout the application to rebrand from "Collections" to "Record Collections", providing a more descriptive and specific name for the record/album collection platform.

## Changes Made
- **Page metadata**: Updated the browser tab title in `app/layout.tsx`
- **Registration page**: Updated welcome text in `app/register/page.tsx`
- **Shared collection page**: Updated the public collection description in `app/u/[shareSlug]/page.tsx`
- **Navigation**: Updated the wordmark/logo text in `components/NavBar.tsx`
- **Footer**: Updated the branding text in `components/SiteFooter.tsx`

## Details
All instances of the app name "Collections" have been consistently replaced with "Record Collections" across the application's UI, including:
- Page titles and metadata
- Welcome/onboarding text
- Public-facing descriptions
- Navigation and branding elements
- Footer content

This change maintains consistency across all user touchpoints while making the app's purpose more explicit.

https://claude.ai/code/session_01MLZ1iyq2wwa7MNx2epsEan