### PR TITLE
Refactor components to use responsive utilities and improve dark mode support

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -21,21 +21,13 @@ function isActive(pathname: string, href: string) {
   return pathname.startsWith(href);
 }
 
-function Wordmark({ small = false }: { small?: boolean }) {
+function Wordmark() {
   return (
     <Link
       href="/"
-      className={clsx(
-        "flex items-center font-display font-extrabold tracking-[-0.02em]",
-        small ? "gap-2 text-[19px]" : "gap-[9px] text-[20px]"
-      )}
+      className="flex items-center gap-[9px] font-display text-[19px] font-extrabold leading-[1.1] tracking-[-0.02em] dt:text-[20px] dt:leading-[normal]"
     >
-      <span
-        className={clsx(
-          "rounded-full bg-accent shadow-[0_0_12px_var(--accent-glow)]",
-          small ? "h-2 w-2" : "h-[9px] w-[9px]"
-        )}
-      />
+      <span className="hidden h-[9px] w-[9px] shrink-0 rounded-full bg-accent shadow-[0_0_12px_var(--accent-glow)] dt:block" />
       Record Collections
     </Link>
   );
@@ -245,7 +237,7 @@ export default function NavBar() {
       {/* Mobile top bar */}
       <div className="sticky top-0 z-20 border-b border-nav-border bg-bg dt:hidden">
         <div className="flex items-center justify-between px-[18px] py-4">
-          <Wordmark small />
+          <Wordmark />
           <div className="flex items-center gap-3">
             <ThemeToggle iconOnly />
             <Link href="/user-profile">

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -25,7 +25,7 @@ function Wordmark() {
   return (
     <Link
       href="/"
-      className="flex items-center gap-[9px] font-display text-[19px] font-extrabold leading-[1.1] tracking-[-0.02em] dt:text-[20px] dt:leading-[normal]"
+      className="flex items-center gap-[9px] font-display text-[19px] font-extrabold leading-none tracking-[-0.02em] dt:text-[20px] dt:leading-[normal]"
     >
       <span className="hidden h-[9px] w-[9px] shrink-0 rounded-full bg-accent shadow-[0_0_12px_var(--accent-glow)] dt:block" />
       Record Collections

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -14,7 +14,7 @@ export default function SiteFooter() {
   if (isLoading || user || pathname !== "/") return null;
 
   return (
-    <footer style={{ background: "#141b2e" }}>
+    <footer className="bg-[#141b2e] dark:bg-surface">
       <div className="mx-auto flex max-w-[1160px] flex-wrap items-center justify-between gap-x-7 gap-y-4 px-[18px] py-5 dt:px-8">
         <div className="flex flex-wrap items-center gap-5">
           <span className="font-display text-[14px] font-bold tracking-[-0.01em] text-[#9aa3b8]">

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -16,21 +16,21 @@ export default function SiteFooter() {
   return (
     <footer className="bg-[#141b2e] dark:bg-surface">
       <div className="mx-auto flex max-w-[1160px] flex-wrap items-center justify-between gap-x-7 gap-y-4 px-[18px] py-5 dt:px-8">
-        <div className="flex flex-wrap items-center gap-5">
-          <span className="font-display text-[14px] font-bold tracking-[-0.01em] text-[#9aa3b8]">
+        <div className="flex flex-wrap items-center gap-4">
+          <span className="font-display text-[14px] font-bold tracking-[-0.01em] text-[#9aa3b8] dark:text-text">
             Record Collections
           </span>
           <div className="flex flex-wrap gap-[18px]">
             {links.map((label) => (
-              <span key={label} className="text-[13px] text-[#6f7a92]">
+              <span key={label} className="text-[13px] text-[#6f7a92] dark:text-text">
                 {label}
               </span>
             ))}
           </div>
         </div>
-        <p className="m-0 font-body text-[11px] tracking-[0.05em] text-[#6f7a92]">
+        <p className="m-0 font-body text-[11px] tracking-[0.05em] text-[#6f7a92] dark:text-text">
           © 2026 · Designed &amp; built by{" "}
-          <span className="font-semibold text-[#9aa3b8]">Grounded Workflows Co.</span>
+          <span className="font-semibold text-[#9aa3b8] dark:text-text">Grounded Workflows Co.</span>
         </p>
       </div>
     </footer>

--- a/components/landing/Landing.tsx
+++ b/components/landing/Landing.tsx
@@ -149,13 +149,10 @@ export default function Landing() {
       {charts.length > 0 ? (
         <div className="border-t border-nav-border bg-surface">
           <div className="mx-auto max-w-[720px] px-[18px] py-[clamp(48px,7vw,76px)] dt:px-8">
-            <div className="mb-[26px] flex flex-wrap items-baseline justify-between gap-2">
+            <div className="mb-[26px] text-center">
               <h2 className="font-display text-[clamp(24px,3.2vw,32px)] font-extrabold tracking-[-0.03em] text-text">
                 Most Collected All Time
               </h2>
-              <span className="font-body text-[12px] uppercase tracking-[0.1em] text-muted">
-                The Charts
-              </span>
             </div>
             {charts.map((album, i) => (
               <div


### PR DESCRIPTION
## Summary
This PR refactors several components to use responsive utility classes instead of conditional rendering, improves dark mode support in the footer, and simplifies the Wordmark component by removing its size variant prop.

## Key Changes

- **NavBar.tsx**
  - Removed the `small` prop from the `Wordmark` component and simplified its implementation
  - Replaced conditional className logic with responsive utility classes using the `dt:` (desktop) breakpoint prefix
  - The accent dot now uses `hidden dt:block` to show only on desktop, with the mobile version removed
  - Updated the Wordmark call site to remove the `small` prop

- **SiteFooter.tsx**
  - Converted inline `style` prop to Tailwind className (`bg-[#141b2e] dark:bg-surface`)
  - Added dark mode support across all text elements with `dark:text-text` classes
  - Adjusted gap spacing from `gap-5` to `gap-4` for better visual consistency

- **Landing.tsx**
  - Simplified the "Most Collected All Time" section header layout
  - Changed from `flex flex-wrap items-baseline justify-between` to `text-center` for cleaner alignment
  - Removed the "The Charts" subtitle span to reduce visual clutter

## Implementation Details
The changes leverage Tailwind's responsive prefix system (`dt:`) and dark mode modifiers to eliminate the need for conditional rendering logic, making the code more maintainable and reducing component complexity.

https://claude.ai/code/session_01SU8kdEjtC7FLFTswZEnkPD